### PR TITLE
Fix SonarCloud CI configuration

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -2,27 +2,26 @@ name: SonarCloud
 
 on:
   workflow_run:
-    workflows:
-      - Tests (PHP)
-    types:
-      - completed
+    workflows: ["Tests (PHP)"]
+    types: [completed]
 
 jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
-
     permissions:
       actions: read
       contents: read
       pull-requests: write
-
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Download test artifacts
+        continue-on-error: true
         uses: actions/download-artifact@v5
         with:
           name: test-results
@@ -35,7 +34,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
-            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=catch-oss_tmhOAuth
+sonar.organization=catch-design
+
+# Source and test paths
+sonar.sources=.
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+
+# PHP coverage - these paths match the test.yml output
+sonar.php.coverage.reportPaths=coverage/php/coverage.xml
+sonar.php.tests.reportPath=coverage/php/junit.xml
+
+# Exclusions
+sonar.exclusions=vendor/**,tests/**,coverage/**,.github/**


### PR DESCRIPTION
Removes broken secret-based args from sonar.yml and adds sonar-project.properties with project key and org. Fixes checkout to use workflow_run head SHA.