### PR TITLE
Fix sonar quality gate API call

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -71,10 +71,11 @@ jobs:
       - name: Fail job if Quality Gate fails
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_REF: ${{ steps.sonar-ref.outputs.ref }}
         run: |
           if ! RESPONSE=$(curl --fail --silent \
             -H "Authorization: Bearer $SONAR_TOKEN" \
-            "https://sonarcloud.io/api/measures/component?metricKeys=alert_status&component=$SONAR_PROJECT_KEY&${{ steps.sonar-ref.outputs.ref }}"); then
+            "https://sonarcloud.io/api/measures/component?metricKeys=alert_status&component=$SONAR_PROJECT_KEY&$SONAR_REF"); then
             echo "Failed to fetch quality gate status from SonarCloud API"
             exit 1
           fi
@@ -87,8 +88,9 @@ jobs:
         id: sonarqube-report
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_REF: ${{ steps.sonar-ref.outputs.ref }}
         run: |
-          REF="${{ steps.sonar-ref.outputs.ref }}"
+          REF="$SONAR_REF"
 
           if ! DATA=$(curl --fail --silent --request GET \
             --url "https://sonarcloud.io/api/measures/component?metricKeys=alert_status%2Cbugs%2Ccode_smells%2Ccoverage%2Cduplicated_lines_density%2Cncloc%2Creliability_rating%2Csecurity_rating%2Csqale_index%2Csqale_rating%2Cvulnerabilities&component=$SONAR_PROJECT_KEY&$REF" \

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -57,11 +57,14 @@ jobs:
 
       - name: Resolve SonarCloud ref
         id: sonar-ref
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "${{ github.event.workflow_run.pull_requests[0].number }}" != "" ]; then
-            echo "ref=pullRequest=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+          if [ "$PR_NUMBER" != "" ]; then
+            echo "ref=pullRequest=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           else
-            ENCODED_REF=$(echo "${{ github.event.workflow_run.head_branch }}" | jq -sRr @uri)
+            ENCODED_REF=$(printf '%s' "$HEAD_BRANCH" | jq -sRr @uri)
             echo "ref=branch=$ENCODED_REF" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary
- Fix trailing newline (`%0A`) in branch URL encoding that broke the SonarCloud quality gate API call
- `printf '%s'` replaces `echo` to avoid the trailing newline that `jq -sRr @uri` was encoding

## Test plan
- [ ] Verify sonar workflow completes successfully on push
- [ ] Quality gate status is fetched correctly for branches with `/` in name (e.g. `release/6`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)